### PR TITLE
fix: avoid passing null to json_decode PHP8.1

### DIFF
--- a/src/UserPreferences.php
+++ b/src/UserPreferences.php
@@ -71,6 +71,11 @@ class UserPreferences
 
         self::$hasLoaded = true;
 
+        if(is_null($data[0])) {
+            self::$preferences = (object) config('user-preferences.defaults');
+            return;
+        }
+        
         $preferences = json_decode($data[0]->{config('user-preferences.database.column')});
 
         if (json_last_error() !== JSON_ERROR_NONE) {


### PR DESCRIPTION
The exception:
```
json_decode(): Passing null to parameter #1 ($json) of type string is deprecated
```

Cause: 
PHP 8.1 doesn't accept passing `null` values to functions with specific value type like `string` in the case of the function `json_decode` (php.net)[https://www.php.net/manual/en/function.json-decode]

```
json_decode(
    string $json,
    ?bool $associative = null,
    int $depth = 512,
    int $flags = 0
): mixed
```

Fix:
Added a condition that checks if `$data` is null and takes default preferences if true.

