### PR TITLE
Allow string userIds (uuid/ulid/etc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `robtrehy/laravel-user-preferences` will be documented in this file.
 
+## 4.2.1 - 2026-07-21
+- Cache preference column values as scalars instead of Collections (Laravel 13 `serializable_classes` compatibility)
+
 ## 4.2.0 - 2026-07-21
 - Added support for Laravel 13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `robtrehy/laravel-user-preferences` will be documented in this file.
 
+## 4.2.0 - 2026-07-21
+- Added support for Laravel 13
+
 ## 4.1.3 - 2025-11-10
 - Hotfix: Ensure when the database column is null, `UserPreferences::all()` applies the defaults and does not trigger a json_decode(null) warning
 

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
     ],
     "require": {
         "php": "^8.1",
-        "laravel/framework": "^10.0|^11.0|^12.0"
+        "laravel/framework": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5|^11.0|^12.0",
         "squizlabs/php_codesniffer": "^3.6|^3.7",
         "nunomaduro/collision": "^7.0|^8.0",
-        "orchestra/testbench": "^8.20|^9.0|^10.2"
+        "orchestra/testbench": "^8.20|^9.0|^10.2|^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/UserPreferences.php
+++ b/src/UserPreferences.php
@@ -40,9 +40,9 @@ class UserPreferences
     /**
      * Check for preferences, load if not already loaded for this user.
      *
-     * @param int|null $userId
+     * @param int|string|null $userId
      */
-    protected static function preferencesLoaded(?int $userId = null)
+    protected static function preferencesLoaded(mixed $userId = null)
     {
         $userId = $userId ?? Auth::id();
         if (self::$hasLoadedCache[$userId] ?? false) {
@@ -59,9 +59,9 @@ class UserPreferences
      *
      * If the preferences column is empty, the default preferences will be loaded from config.
      *
-     * @param int|null $userId
+     * @param int|string|null $userId
      */
-    protected static function getPreferences(?int $userId = null)
+    protected static function getPreferences(mixed $userId = null)
     {
         $userId = $userId ?? Auth::id();
 
@@ -94,9 +94,9 @@ class UserPreferences
     /**
      * Set the default preferences for a user
      *
-     * @param int|null $userId
+     * @param int|string|null $userId
      */
-    public static function setDefaultPreferences(?int $userId = null)
+    public static function setDefaultPreferences(mixed $userId = null)
     {
         self::preferencesLoaded($userId);
         self::save($userId);
@@ -108,10 +108,10 @@ class UserPreferences
      * Returns the preference if set, otherwise returns the default value from config.
      *
      * @param string $key
-     * @param int|null $userId
+     * @param int|string|null $userId
      * @return mixed
      */
-    public static function get(string $key, ?int $userId = null)
+    public static function get(string $key, mixed $userId = null)
     {
         self::preferencesLoaded($userId);
         $userId = $userId ?? Auth::id();
@@ -129,9 +129,9 @@ class UserPreferences
      *
      * @param string $key
      * @param mixed $value
-     * @param int|null $userId
+     * @param int|string|null $userId
      */
-    public static function set(string $key, $value, ?int $userId = null)
+    public static function set(string $key, $value, mixed $userId = null)
     {
         self::preferencesLoaded($userId);
         $userId = $userId ?? Auth::id();
@@ -155,10 +155,10 @@ class UserPreferences
      * Returns true if restored to default, false if preference was deleted.
      *
      * @param string $key
-     * @param int|null $userId
+     * @param int|string|null $userId
      * @return bool
      */
-    public static function reset(string $key, ?int $userId = null)
+    public static function reset(string $key, mixed $userId = null)
     {
         self::preferencesLoaded($userId);
         $userId = $userId ?? Auth::id();
@@ -178,10 +178,10 @@ class UserPreferences
      * Check if a preference exists for a user.
      *
      * @param string $key
-     * @param int|null $userId
+     * @param int|string|null $userId
      * @return bool
      */
-    public static function has(string $key, ?int $userId = null)
+    public static function has(string $key, mixed $userId = null)
     {
         self::preferencesLoaded($userId);
         $userId = $userId ?? Auth::id();
@@ -191,10 +191,10 @@ class UserPreferences
     /**
      * Get all preferences as an object.
      *
-     * @param int|null $userId
+     * @param int|string|null $userId
      * @return object
      */
-    public static function all(?int $userId = null)
+    public static function all(mixed $userId = null)
     {
         self::preferencesLoaded($userId);
         $userId = $userId ?? Auth::id();
@@ -204,9 +204,9 @@ class UserPreferences
     /**
      * Save all preferences to the database.
      *
-     * @param int|null $userId
+     * @param int|string|null $userId
      */
-    protected static function save(?int $userId = null)
+    protected static function save(mixed $userId = null)
     {
         $userId = $userId ?? Auth::id();
         DB::table(config('user-preferences.database.table'))
@@ -219,9 +219,9 @@ class UserPreferences
     /**
      * Reset the cache for a given user.
      *
-     * @param int|null $userId
+     * @param int|string|null $userId
      */
-    protected static function resetCache(?int $userId = null)
+    protected static function resetCache(mixed $userId = null)
     {
         $userId = $userId ?? Auth::id();
         Cache::forget(config('user-preferences.cache.prefix') . $userId . config('user-preferences.cache.suffix'));

--- a/src/UserPreferences.php
+++ b/src/UserPreferences.php
@@ -65,21 +65,23 @@ class UserPreferences
     {
         $userId = $userId ?? Auth::id();
 
-        $data = Cache::rememberForever(
+        // Cache the JSON column value only — Laravel 13 disallows unserializing
+        // arbitrary classes (e.g. Collections) from the cache by default.
+        $column = config('user-preferences.database.column');
+        $rawPreferences = Cache::rememberForever(
             config('user-preferences.cache.prefix') . $userId . config('user-preferences.cache.suffix'),
-            function () use ($userId) {
+            function () use ($userId, $column) {
                 return DB::table(config('user-preferences.database.table'))
-                    ->select(config('user-preferences.database.column'))
                     ->where(config('user-preferences.database.primary_key'), $userId)
-                    ->get();
+                    ->value($column);
             }
         );
 
-        if ($data->isEmpty() || is_null($data[0]->{config('user-preferences.database.column')})) {
+        if (is_null($rawPreferences)) {
             // No row or column is null → use defaults
             self::$preferencesCache[$userId] = (object) config('user-preferences.defaults');
         } else {
-            $preferences = json_decode($data[0]->{config('user-preferences.database.column')});
+            $preferences = json_decode($rawPreferences);
             if (json_last_error() !== JSON_ERROR_NONE || is_null($preferences)) {
                 // Invalid JSON → fallback to defaults
                 self::$preferencesCache[$userId] = (object) config('user-preferences.defaults');


### PR DESCRIPTION
Been using this package for a while, but the latest version does not work with ULID or UUID user IDs.

Updated the userId type hinting to mixed to make it work